### PR TITLE
Fix rotational group platform type enum value

### DIFF
--- a/ark_sdk_python/models/services/pcloud/platforms/ark_pcloud_platform.py
+++ b/ark_sdk_python/models/services/pcloud/platforms/ark_pcloud_platform.py
@@ -9,7 +9,7 @@ from ark_sdk_python.models.ark_model import ArkCamelizedModel
 class ArkPCloudPlatformType(str, Enum):
     Regular = 'regular'
     Group = 'group'
-    RotationalGroups = 'rotationalGroups'
+    RotationalGroups = 'rotationalgroup'
     Dependent = 'dependent'
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ark-sdk-python"
-version = "2.0.13"
+version = "2.0.14"
 description='Official Ark SDK / CLI for CyberArk Identity Security Platform'
 authors = ["CyberArk <cyberark@cyberark.com>", "Ofir Iluz <ofir.iluz@cyberark.com"]
 readme = "README.md"


### PR DESCRIPTION
### Desired Outcome

Fix the `list_platforms()` method failing with an enum validation error when encountering rotational group platforms. The method should successfully parse all platform types returned by the API without validation errors.

### Implemented Changes

**What's changed?**
- Updated the `ArkPCloudPlatformType` enum value from `'rotationalGroups'` (plural) to `'rotationalgroup'` (singular) to match the actual API response

**Why were these changes made?**
- The API returns `'rotationalgroup'` but the enum expected `'rotationalGroups'`, causing Pydantic validation to fail with: `Input should be 'regular', 'group', 'rotationalGroups' or 'dependent' [type=enum, input_value='rotationalgroup', input_type=str]`

**How should the reviewer approach this PR?**
- Review the single line change in `ark_pcloud_platform.py:12`
- The fix has been tested against the live API and successfully resolves the validation error
- No manual testing required - the change is a simple string value correction

### Connected Issue/Story

Resolves user-reported issue where `list_platforms()` method fails with enum validation error for rotational group platforms.

CyberArk internal issue ID: [N/A - user-reported bug]

### Definition of Done

#### Changelog

- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation

#### Behavior

- [x] No behavior was changed with this PR

#### Security

- [x] There are no security aspects to these changes